### PR TITLE
cleanup old KMS key versions

### DIFF
--- a/deployment/accounts/gcp/audit/csp/BUILD
+++ b/deployment/accounts/gcp/audit/csp/BUILD
@@ -3,6 +3,9 @@ subinclude("//build/defs:terraform")
 terraform_per_account(
     srcs = [
         "bucket.tf",
+        "cleanup-kms-key-versions.tf",
+        "cleanup-kms-key-versions/main.py",
+        "cleanup-kms-key-versions/requirements.txt",
         "main.tf",
         "sink.tf",
         "variables.tf",

--- a/deployment/accounts/gcp/audit/csp/bucket.tf
+++ b/deployment/accounts/gcp/audit/csp/bucket.tf
@@ -65,11 +65,22 @@ resource "google_kms_crypto_key" "audit_csp" {
 
   name            = "${var.name}-audit-csp"
   key_ring        = google_kms_key_ring.audit_csp.id
-  rotation_period = "86400s"
+  rotation_period = "1209600s" # 2 weeks
 
   lifecycle {
     prevent_destroy = true
   }
+}
+
+resource "google_kms_crypto_key_iam_binding" "audit_csp" {
+  provider = google-beta.logs
+
+  crypto_key_id = google_kms_crypto_key.audit_csp.id
+  role          = "roles/cloudkms.admin"
+
+  members = [
+    "serviceAccount:${google_service_account.function.email}",
+  ]
 }
 
 data "google_storage_project_service_account" "logs" {

--- a/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions.tf
+++ b/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions.tf
@@ -1,0 +1,131 @@
+locals {
+  fn_id = "fn-${substr(sha1("${var.name}-kms-key-cleaner"), 0, 7)}"
+}
+
+resource "google_project_service" "cloudfunctions" {
+  provider = google-beta.logs
+
+  service = "cloudfunctions.googleapis.com"
+
+  disable_dependent_services = true
+
+  depends_on = [
+    google_project_service.cloudbuild,
+  ]
+}
+
+resource "google_project_service" "cloudbuild" {
+  provider = google-beta.logs
+
+  service = "cloudbuild.googleapis.com"
+
+  disable_dependent_services = true
+}
+
+resource "google_cloudfunctions_function" "function" {
+  provider = google-beta.logs
+
+  region = "europe-west1"
+
+  name        = local.fn_id
+  description = "Cleans up old KMS keys for ${var.name}"
+  runtime     = "python39"
+
+  available_memory_mb   = 128
+  source_archive_bucket = google_storage_bucket.function.name
+  source_archive_object = google_storage_bucket_object.function.name
+  entry_point           = "cleanup"
+
+  service_account_email = google_service_account.function.email
+
+  environment_variables = {
+    CRYPTO_KEY_ID = google_kms_crypto_key.audit_csp.id
+  }
+
+  event_trigger {
+    event_type = "google.pubsub.topic.publish"
+    resource   = google_pubsub_topic.function_trigger.id
+  }
+
+  depends_on = [
+    google_project_service.cloudfunctions,
+    google_project_service.cloudbuild,
+  ]
+}
+
+resource "google_service_account" "function" {
+  provider = google-beta.logs
+
+  account_id   = local.fn_id
+  display_name = "${var.name}-kms-key-cleaner"
+}
+
+resource "google_storage_bucket" "function" {
+  provider = google-beta.logs
+
+  name          = local.fn_id
+  location      = "EUROPE-WEST1"
+  force_destroy = true
+
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "function" {
+  provider = google-beta.logs
+
+  name   = "cleanup-kms-key-versions.${data.archive_file.function.output_md5}.zip"
+  source = data.archive_file.function.output_path
+  bucket = google_storage_bucket.function.name
+}
+
+data "archive_file" "function" {
+  type = "zip"
+
+  source {
+    content  = file("${path.module}/main.py")
+    filename = "main.py"
+  }
+
+  source {
+    content  = file("${path.module}/requirements.txt")
+    filename = "requirements.txt"
+  }
+
+  output_path = "${path.module}/cleanup-kms-key-versions.zip"
+}
+
+resource "google_pubsub_topic" "function_trigger" {
+  provider = google-beta.logs
+
+  name = "${local.fn_id}-trigger"
+
+  message_retention_duration = "600s"
+}
+
+resource "google_project_service" "cloudscheduler" {
+  provider = google-beta.logs
+
+  service = "cloudscheduler.googleapis.com"
+
+  disable_dependent_services = true
+}
+
+resource "google_cloud_scheduler_job" "function_trigger" {
+  provider = google-beta.logs
+
+  region = "europe-west1"
+
+  name        = "${local.fn_id}-cron"
+  description = "${var.name}-kms-key-cleaner-cron"
+  schedule    = "0 0 1,15 * *"
+
+  pubsub_target {
+    # topic.id is the topic's full resource name.
+    topic_name = google_pubsub_topic.function_trigger.id
+    data       = base64encode("{}")
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+  ]
+}

--- a/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions/main.py
+++ b/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions/main.py
@@ -1,0 +1,84 @@
+
+def cleanup(event, context):
+    """Background Cloud Function to be triggered by Pub/Sub.
+    Args:
+         event (dict):  The dictionary with data specific to this type of
+                        event. The `@type` field maps to
+                         `type.googleapis.com/google.pubsub.v1.PubsubMessage`.
+                        The `data` field maps to the PubsubMessage data
+                        in a base64-encoded string. The `attributes` field maps
+                        to the PubsubMessage attributes if any is present.
+         context (google.cloud.functions.Context): Metadata of triggering event
+                        including `event_id` which maps to the PubsubMessage
+                        messageId, `timestamp` which maps to the PubsubMessage
+                        publishTime, `event_type` which maps to
+                        `google.pubsub.topic.publish`, and `resource` which is
+                        a dictionary that describes the service API endpoint
+                        pubsub.googleapis.com, the triggering topic's name, and
+                        the triggering event type
+                        `type.googleapis.com/google.pubsub.v1.PubsubMessage`.
+    Returns:
+        None. The output is written to Cloud Logging.
+    """
+    from google.cloud import kms
+    import os
+
+    client = kms.KeyManagementServiceClient()
+
+    crypto_key_id = os.getenv("CRYPTO_KEY_ID")
+
+    # get primary crypto key version from crypto key
+    crypto_key = client.get_crypto_key(
+        request=kms.GetCryptoKeyRequest(
+            name=crypto_key_id,
+        ),
+    )
+    primary_crypto_key_version = crypto_key.primary
+    
+
+    # list current crypto key versions
+    list_resp = client.list_crypto_key_versions(
+        request=kms.ListCryptoKeyVersionsRequest(
+            parent=crypto_key_id,
+            page_size=100,
+        ),
+    )
+
+    most_recent_non_primary_version = None
+
+    # determine the most recent non-primary version
+    for crypto_key_version in list_resp.crypto_key_versions:
+        if crypto_key_version.name == primary_crypto_key_version.name:
+            # skip the primary version
+            continue
+        
+        if (
+            most_recent_non_primary_version == None or 
+            crypto_key_version.create_time.rfc3339() > most_recent_non_primary_version.create_time.rfc3339()
+            ):
+            most_recent_non_primary_version = crypto_key_version
+
+    print(f"keeping primary: {primary_crypto_key_version.name}")
+    print(f"keeping most-recent non-primary: {most_recent_non_primary_version.name}")
+        
+    # destroy keys which are not the primary or most-recent non-primary version
+    for crypto_key_version in list_resp.crypto_key_versions:
+        if crypto_key_version.name == primary_crypto_key_version.name:
+            # skip the primary version
+            continue
+        if crypto_key_version.name == most_recent_non_primary_version.name:
+            # skip the most-recent non-primary version
+            continue
+
+        # skip if already scheduled for destroy or destroyed
+        if crypto_key_version.state == kms.CryptoKeyVersion.CryptoKeyVersionState.DESTROY_SCHEDULED:
+            continue
+        if crypto_key_version.state == kms.CryptoKeyVersion.CryptoKeyVersionState.DESTROYED:
+            continue
+
+        print(f"destroying: {crypto_key_version.name}")
+        destroy_resp = client.destroy_crypto_key_version(
+            request=kms.DestroyCryptoKeyVersionRequest(
+                name=crypto_key_version.name,
+            ),
+        )

--- a/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions/requirements.txt
+++ b/deployment/accounts/gcp/audit/csp/cleanup-kms-key-versions/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-kms==2.11.1

--- a/deployment/accounts/gcp/audit/csp/main.tf
+++ b/deployment/accounts/gcp/audit/csp/main.tf
@@ -4,6 +4,11 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "4.5.0"
     }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
   }
 }
 
@@ -15,4 +20,7 @@ provider "google-beta" {
   alias = "logs"
 
   project = "vjp-logs"
+}
+
+provider "archive" {
 }


### PR DESCRIPTION
In March 2022, I spent £19.15 on 426.432 _Active software symmetric key versions_ as rotating your KMS keys does not delete the old versions (with good reason). As I had configured them to rotate daily this meant that I had > 50 key versions for each key. 

I've reconfigured to set my key rotation to the same length as the object retention period and written a cloud function to clean up all but the most recent 2 key versions so that keys are gracefully deleted when they are moot.