### PR TITLE
include intermediary GitHub Action thumbprint

### DIFF
--- a/deployment/github-actions/aws/oidc.tf
+++ b/deployment/github-actions/aws/oidc.tf
@@ -7,5 +7,8 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
     "sts.amazonaws.com",
   ]
 
-  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
 }


### PR DESCRIPTION
GitHub Actions have reported that there are 2 currently active thumbprints, this commit updates to use. This had to be applied manually.

See https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/